### PR TITLE
Add support for negated destination addresses

### DIFF
--- a/lib/puppet/type/iptables.rb
+++ b/lib/puppet/type/iptables.rb
@@ -240,15 +240,22 @@ module Puppet
             end
           end
 
-          destination = self.matched(l.scan(/-d (\S+)/))
+          destination = self.matched(l.scan(/-d ((! )?(\S+))/))
           if destination
-            ip = IpCidr.new(destination)
+
+            negator = $2
+            dest_ip = $3
+
+            ip = IpCidr.new(dest_ip)
             if @@usecidr
               destination = ip.cidr
             else
               destination = ip.to_s
               destination += sprintf("/%s", ip.netmask) unless ip.prefixlen == 32
             end
+
+            destination = "#{negator}#{destination}"
+
           end
 
           sport = self.matched(l.scan(/--sport[s]? (\S+)/))


### PR DESCRIPTION
Without this patch, Puppet runs to error out with "Could not evaluate: invalid address" when a negated destination address is used (e.g. "-d ! 192.168.1.0/255.255.255.0").

While this concept could be expanded elsewhere within iptables.rb where negation is allowed, I've limited it to destination addresses because:

a) This solved my immediate problem;
b) There might be a more graceful way to do this; and
c) There could be bugs in my implementation.

Thanks for your consideration.

-Andy
